### PR TITLE
Fixed scope of `util` variable

### DIFF
--- a/info.lua
+++ b/info.lua
@@ -9,6 +9,7 @@ local found = sys.fexecute('which identify'):find('identify')
 local parseExif = require 'graphicsmagick.exif'
 
 -- Which util:
+local util
 if found then
    util = 'identify '
 else


### PR DESCRIPTION
This was causing trouble with the global namespace (especially given that `util` is a common package name).
