### PR TITLE
exposed more gm functions + fixed clone memory leak 

### DIFF
--- a/Image.lua
+++ b/Image.lua
@@ -515,12 +515,16 @@ function Image:flop()
 end
 
 -- Rotate:
-function Image:rotate(deg)
+function Image:rotate(deg, r, g, b)
    -- Create PixelWand:
    local pixelwand = ffi.gc(clib.NewPixelWand(), function(pixelwand)
       -- Collect:
       clib.DestroyPixelWand(pixelwand)
    end)
+   clib.PixelSetRed(pixelwand, r or 0)
+   clib.PixelSetGreen(pixelwand, g or 0)
+   clib.PixelSetBlue(pixelwand, b or 0)
+
    -- Rotate image:
    clib.MagickRotateImage(self.wand, pixelwand, deg)
 

--- a/Image.lua
+++ b/Image.lua
@@ -106,7 +106,7 @@ ffi.cdef
   // Global context:
   void MagickWandGenesis();
   void InitializeMagick();
-  
+
   // Magick Wand:
   MagickWand* NewMagickWand();
   MagickWand* DestroyMagickWand(MagickWand*);
@@ -127,7 +127,7 @@ ffi.cdef
 
   // Quality:
   unsigned int MagickSetCompressionQuality( MagickWand *wand, const unsigned long quality );
- 
+
   //Exception handling:
   const char* MagickGetException(const MagickWand*, ExceptionType*);
 
@@ -159,9 +159,9 @@ ffi.cdef
                                      const char *map, const StorageType storage,
                                      unsigned char *pixels );
 
-   // Flip/Flop
-   unsigned int MagickFlipImage( MagickWand *wand );
-   unsigned int MagickFlopImage( MagickWand *wand );
+  // Flip/Flop
+  unsigned int MagickFlipImage( MagickWand *wand );
+  unsigned int MagickFlopImage( MagickWand *wand );
 
   // Rotate
   unsigned int MagickRotateImage( MagickWand *wand, const PixelWand *background,
@@ -174,12 +174,12 @@ ffi.cdef
   unsigned int MagickBorderImage( MagickWand *wand, const PixelWand *bordercolor,
                                 const unsigned long width, const unsigned long height );
 
-   // Colorspace:
-   ColorspaceType MagickGetImageColorspace( MagickWand *wand );
-   unsigned int MagickSetImageColorspace( MagickWand *wand, const ColorspaceType colorspace );
+  // Colorspace:
+  ColorspaceType MagickGetImageColorspace( MagickWand *wand );
+  unsigned int MagickSetImageColorspace( MagickWand *wand, const ColorspaceType colorspace );
 
-   // Description
-   const char *MagickDescribeImage( MagickWand *wand );
+  // Description
+  const char *MagickDescribeImage( MagickWand *wand );
 ]]
 -- Load lib:
 local clib = ffi.load('GraphicsMagickWand')
@@ -217,25 +217,25 @@ function Image.new(pathOrTensor, ...)
       -- Collect:
       clib.DestroyMagickWand(wand)
    end)
-  
+
    -- Arg?
    if type(pathOrTensor) == 'string' then
       -- Is a path:
       image:load(pathOrTensor, ...)
-   
+
    elseif type(pathOrTensor) == 'userdata' then
       -- Is a tensor:
       image:fromTensor(pathOrTensor, ...)
 
    end
-   
-   -- 
+
+   --
    return image
 end
 
 function Image:clone()
    local out = Image()
-   for k,v in pairs(Image) do      
+   for k,v in pairs(Image) do
       out[k] = self[k]
    end
    for k,v in pairs(out.buffers) do
@@ -257,7 +257,7 @@ function Image:load(path, width, height)
 
    -- Load image:
    local status = clib.MagickReadImage(self.wand, path)
-   
+
    -- Error?
    if status == 0 then
       clib.DestroyMagickWand(self.wand)
@@ -280,11 +280,11 @@ function Image:save(path, quality)
 
    -- Set quality:
    quality = quality or 85
-   clib.MagickSetCompressionQuality(self.wand, quality) 
+   clib.MagickSetCompressionQuality(self.wand, quality)
 
    -- Save:
    local status = clib.MagickWriteImage(self.wand, path)
-   
+
    -- Error?
    if status == 0 then
       error(self.name .. ': error saving image to path "' .. path .. '"')
@@ -314,7 +314,7 @@ function Image:size(width,height,filter)
             width = box * cwidth/cheight
          end
       end
-      
+
       -- Min box?
       if not width then
          -- in this case, the image must cover a heightxheight box:
@@ -361,7 +361,7 @@ function Image:depth(depth)
       local depth = clib.MagickGetImageDepth(self.wand)
    end
    --
-   return depth 
+   return depth
 end
 
 -- Format:
@@ -423,7 +423,7 @@ function Image:colorspace(colorspace)
 
       colorspace = colorspaces[colorspace]
    end
-   return colorspace 
+   return colorspace
 end
 
 -- Flip:
@@ -494,15 +494,15 @@ function Image:toBlob(quality)
       print('please call image:format(fmt) before (format = JPEG, PNG, ...')
       error()
    end
-   
+
    -- Set quality:
    if quality then
-      clib.MagickSetCompressionQuality(self.wand, quality) 
+      clib.MagickSetCompressionQuality(self.wand, quality)
    end
 
    -- To Blob:
    local blob = ffi.gc(clib.MagickWriteImageBlob(self.wand, sizep), ffi.C.free)
-   
+
    -- Return blob and size:
    return blob, tonumber(sizep[0])
 end
@@ -562,7 +562,7 @@ function Image:toTensor(dataType, colorspace, dims, nocopy)
    local ptx = torch.data(tensor)
 
    -- Export:
-   clib.MagickGetImagePixels(self.wand, 
+   clib.MagickGetImagePixels(self.wand,
                              0, 0, width, height,
                              colorspace, clib[pixelType],
                              ffi.cast('unsigned char *',ptx))
@@ -595,7 +595,7 @@ end
 function Image:fromBlob(blob,size)
    -- Read from blob:
    clib.MagickReadImageBlob(self.wand, ffi.cast('const void *', blob), size)
-   
+
    -- Save path:
    self.path = '<blob>'
 
@@ -623,10 +623,10 @@ function Image:fromTensor(tensor, colorspace, dims)
    else -- dims == 'HWD'
       height,width,depth = tensor:size(1),tensor:size(2),tensor:size(3)
    end
-   
+
    -- Force contiguous:
    tensor = tensor:contiguous()
-   
+
    -- Color space:
    if not colorspace then
       if depth == 1 then
@@ -656,7 +656,7 @@ function Image:fromTensor(tensor, colorspace, dims)
    else
       error(Image.name .. ': only dealing with float, double and byte')
    end
-   
+
    -- Raw pointer:
    local ptx = torch.data(tensor)
 
@@ -665,7 +665,7 @@ function Image:fromTensor(tensor, colorspace, dims)
    self:size(width,height)
 
    -- Export:
-   clib.MagickSetImagePixels(self.wand, 
+   clib.MagickSetImagePixels(self.wand,
                              0, 0, width, height,
                              colorspace, clib[pixelType],
                              ffi.cast("unsigned char *", ptx))
@@ -681,7 +681,7 @@ end
 function Image:show(zoom)
    -- Get Tensor from image:
    local tensor = self:toTensor('float', nil,'DHW')
-   
+
    -- Display this tensor:
    require 'image'
    image.display({

--- a/Image.lua
+++ b/Image.lua
@@ -24,6 +24,19 @@ ffi.cdef
     DoublePixel,
   } StorageType;
 
+  // Noise types:
+  typedef enum
+  {
+    UniformNoise,
+    GaussianNoise,
+    MultiplicativeGaussianNoise,
+    ImpulseNoise,
+    LaplacianNoise,
+    PoissonNoise,
+    RandomNoise,
+    UndefinedNoise
+  } NoiseType;
+
   // Resizing filters:
   typedef enum
   {
@@ -233,6 +246,7 @@ ffi.cdef
   unsigned int MagickSetImageBackgroundColor( MagickWand *wand, const PixelWand *background );
   MagickWand *MagickFlattenImages( MagickWand *wand );
   unsigned int MagickBlurImage( MagickWand *wand, const double radius, const double sigma );
+  unsigned int MagickAddNoiseImage( MagickWand *wand, const NoiseType noise_type );
 
   // Composing
   unsigned int MagickCompositeImage( MagickWand *wand, const MagickWand *composite_wand,
@@ -621,6 +635,14 @@ end
 -- Blur image
 function Image:blur(radius, sigma)
   clib.MagickBlurImage(self.wand, radius, sigma)
+  return self
+end
+
+-- Add noise
+function Image:addNoise(noise)
+  -- get noise type
+  local noisetype = clib[noise .. 'Noise']
+  clib.MagickAddNoiseImage(self.wand, noisetype)
   return self
 end
 

--- a/Image.lua
+++ b/Image.lua
@@ -174,6 +174,11 @@ ffi.cdef
   unsigned int MagickBorderImage( MagickWand *wand, const PixelWand *bordercolor,
                                 const unsigned long width, const unsigned long height );
 
+  // Processing
+  unsigned int MagickColorFloodfillImage( MagickWand *wand, const PixelWand *fill,
+                                        const double fuzz, const PixelWand *bordercolor,
+                                        const long x, const long y );
+
   // Colorspace:
   ColorspaceType MagickGetImageColorspace( MagickWand *wand );
   unsigned int MagickSetImageColorspace( MagickWand *wand, const ColorspaceType colorspace );
@@ -477,6 +482,22 @@ function Image:addBorder(w, h, r, g, b)
    clib.PixelSetBlue(pixelwand, b or 0)
    -- Add border:
    clib.MagickBorderImage(self.wand, pixelwand, w, h)
+
+   -- return self
+   return self
+end
+
+function Image:floodFill(x, y, fuzz, r, g, b)
+  -- Create PixelWand:
+   local pixelwand = ffi.gc(clib.NewPixelWand(), function(pixelwand)
+      -- Collect:
+      clib.DestroyPixelWand(pixelwand)
+   end)
+   clib.PixelSetRed(pixelwand, r or 0)
+   clib.PixelSetGreen(pixelwand, g or 0)
+   clib.PixelSetBlue(pixelwand, b or 0)
+   -- Fo flood-fill
+   clib.MagickColorFloodfillImage(self.wand, pixelwand, fuzz, nil, x, y)
 
    -- return self
    return self

--- a/Image.lua
+++ b/Image.lua
@@ -115,7 +115,10 @@ ffi.cdef
   //
   PixelWand *NewPixelWand(void);
   PixelWand *DestroyPixelWand(PixelWand *wand);
-  
+  void PixelSetRed(PixelWand *wand,const double red);
+  void PixelSetGreen(PixelWand *wand,const double green);
+  void PixelSetBlue(PixelWand *wand,const double blue);
+
   // Read/Write:
   MagickBooleanType MagickReadImage(MagickWand*, const char*);
   MagickBooleanType MagickReadImageBlob(MagickWand*, const void*, const size_t);
@@ -167,6 +170,9 @@ ffi.cdef
   // Crop
   unsigned int MagickCropImage( MagickWand *wand, const unsigned long width,
                               const unsigned long height, const long x, const long y );
+
+  unsigned int MagickBorderImage( MagickWand *wand, const PixelWand *bordercolor,
+                                const unsigned long width, const unsigned long height );
 
    // Colorspace:
    ColorspaceType MagickGetImageColorspace( MagickWand *wand );
@@ -455,6 +461,22 @@ end
 -- Crop: (http://www.graphicsmagick.org/wand/magick_wand.html#magickcropimage)
 function Image:crop(w, h, x, y)
    clib.MagickCropImage(self.wand, w, h, x, y)
+
+   -- return self
+   return self
+end
+
+function Image:addBorder(w, h, r, g, b)
+  -- Create PixelWand:
+   local pixelwand = ffi.gc(clib.NewPixelWand(), function(pixelwand)
+      -- Collect:
+      clib.DestroyPixelWand(pixelwand)
+   end)
+   clib.PixelSetRed(pixelwand, r or 0)
+   clib.PixelSetGreen(pixelwand, g or 0)
+   clib.PixelSetBlue(pixelwand, b or 0)
+   -- Add border:
+   clib.MagickBorderImage(self.wand, pixelwand, w, h)
 
    -- return self
    return self

--- a/Image.lua
+++ b/Image.lua
@@ -571,7 +571,7 @@ function Image:addBorder(w, h, r, g, b)
 end
 
 -- Flood-fill
-function Image:floodFill(x, y, fuzz, r, g, b)
+function Image:floodFill(x, y, r, g, b, fuzz)
   -- Create PixelWand:
    local pixelwand = ffi.gc(clib.NewPixelWand(), function(pixelwand)
       -- Collect:
@@ -580,6 +580,8 @@ function Image:floodFill(x, y, fuzz, r, g, b)
    clib.PixelSetRed(pixelwand, r or 0)
    clib.PixelSetGreen(pixelwand, g or 0)
    clib.PixelSetBlue(pixelwand, b or 0)
+   local fuzz = fuzz or 0
+
    -- Do flood-fill
    clib.MagickColorFloodfillImage(self.wand, pixelwand, fuzz, nil, x, y)
 

--- a/Image.lua
+++ b/Image.lua
@@ -246,7 +246,12 @@ function Image:clone()
    for k,v in pairs(out.buffers) do
       v = nil
    end
-   out.wand = clib.CloneMagickWand(self.wand)
+
+   out.wand = ffi.gc(clib.CloneMagickWand(self.wand), function(wand)
+      -- Collect:
+      clib.DestroyMagickWand(wand)
+   end)
+
    return out
 end
 

--- a/Image.lua
+++ b/Image.lua
@@ -247,6 +247,8 @@ ffi.cdef
   MagickWand *MagickFlattenImages( MagickWand *wand );
   unsigned int MagickBlurImage( MagickWand *wand, const double radius, const double sigma );
   unsigned int MagickAddNoiseImage( MagickWand *wand, const NoiseType noise_type );
+  unsigned int MagickColorizeImage( MagickWand *wand, const PixelWand *colorize,
+                                  const PixelWand *opacity );
 
   // Composing
   unsigned int MagickCompositeImage( MagickWand *wand, const MagickWand *composite_wand,
@@ -645,6 +647,21 @@ function Image:addNoise(noise)
   -- get noise type
   local noisetype = clib[noise .. 'Noise']
   clib.MagickAddNoiseImage(self.wand, noisetype)
+  return self
+end
+
+-- Colorize image
+function Image:colorize(r, g, b)
+  -- Create PixelWand:
+  local colorize = ffi.gc(clib.NewPixelWand(), function(pixelwand)
+      -- Collect:
+      clib.DestroyPixelWand(pixelwand)
+  end)
+  clib.PixelSetRed(colorize, r or 0)
+  clib.PixelSetGreen(colorize, g or 0)
+  clib.PixelSetBlue(colorize, b or 0)
+
+  clib.MagickColorizeImage(self.wand, colorize, opacity)
   return self
 end
 

--- a/Image.lua
+++ b/Image.lua
@@ -704,6 +704,7 @@ end
 
 -- To Tensor:
 function Image:toTensor(dataType, colorspace, dims, nocopy)
+   require "torch"
    -- Dims:
    local width,height = self:size()
 
@@ -798,6 +799,7 @@ end
 
 -- From Tensor:
 function Image:fromTensor(tensor, colorspace, dims)
+   require 'torch'
    -- Dims:
    local height,width,depth
    if dims == 'DHW' then


### PR DESCRIPTION
A few more GM functions have been exposed:
* MagickBorderImage
* MagickColorFloodfillImage
* MagickSetImageBackgroundColor
* MagickCompositeImage
* MagickFlattenImages
* MagickBlurImage
* MagickAddNoiseImage

There was also a memory leak in Image:clone() which has been fixed. 