### PR TITLE
resize: use LanczosFilter by default

### DIFF
--- a/Image.lua
+++ b/Image.lua
@@ -401,7 +401,7 @@ function Image:size(width,height,filter)
    -- Set or get:
    if width or height then
       -- Get filter:
-      local filter = clib[(filter or 'Cubic') .. 'Filter']
+      local filter = clib[(filter or 'Undefined') .. 'Filter']
 
       -- Bounding box?
       if not height then


### PR DESCRIPTION
This [commit](https://github.com/clementfarabet/graphicsmagick/commit/3a5129e#diff-54522133cc5c8cb52e72b6dbffca97d3L257) switched from `Lanczos2` to `Cubic` - but I noticed `Cubic` gives *blurry* results.

Since GraphicsMagick uses `LanczosFilter` by default I suggest doing the same which can be obtained by passing `UndefinedFilter`:

* [resize.h#L18](https://github.com/boxerab/graphicsmagick/blob/3cf80dd/magick/resize.h#L18)
* [resize.c#L1339-L1341](https://github.com/boxerab/graphicsmagick/blob/0fd149e/magick/resize.c#L1339-L1341)
