### PR TITLE
added sampling factors

### DIFF
--- a/test/sampling_factors.lua
+++ b/test/sampling_factors.lua
@@ -1,0 +1,16 @@
+local gm = require 'graphicsmagick'
+
+local img = gm.Image('lena.jpg')
+img:samplingFactors({2.0, 1.0, 1.0})
+img:save("yuv420.jpg", 50)
+print(img:samplingFactors())
+-- jpeg:sampling-factor: 2x2,1x1,1x1
+os.execute("identify -verbose yuv420.jpg|grep sampling")
+os.execute("rm -f yuv420.jpg")
+
+img:samplingFactors({1.0, 1.0, 1.0})
+img:save("yuv444.jpg", 50)
+print(img:samplingFactors())
+-- jpeg:sampling-factor: 1x1,1x1,1x1
+os.execute("identify -verbose yuv444.jpg|grep sampling")
+os.execute("rm -f yuv444.jpg")


### PR DESCRIPTION
save()/toBlob() function uses 4:2:0 chroma subsampling when generating JPEG.
This PR allows users to change the sampling factors.