### PR TITLE
fixed RGBA colorspace in fromTensor()

### DIFF
--- a/Image.lua
+++ b/Image.lua
@@ -169,6 +169,22 @@ ffi.cdef
     Rec709YCbCrColorspace  /* YCbCr according to ITU-R 709 */
   } ColorspaceType;
 
+  // Image Type
+  typedef enum
+  {
+    UndefinedType,
+    BilevelType,
+    GrayscaleType,
+    GrayscaleMatteType,
+    PaletteType,
+    PaletteMatteType,
+    TrueColorType,
+    TrueColorMatteType,
+    ColorSeparationType,
+    ColorSeparationMatteType,
+    OptimizeType
+  } ImageType;
+
   // Global context:
   void MagickWandGenesis();
   void InitializeMagick();
@@ -266,6 +282,9 @@ ffi.cdef
   // SamplingFactors
   double *MagickGetSamplingFactors(MagickWand *,unsigned long *);
   unsigned int MagickSetSamplingFactors(MagickWand *,const unsigned long,const double *);
+
+  // ImageType
+  unsigned int MagickSetImageType( MagickWand *, const ImageType );
 ]]
 -- Load lib:
 local clib = ffi.load('GraphicsMagickWand')
@@ -907,7 +926,9 @@ function Image:fromTensor(tensor, colorspace, dims)
    -- Resize image:
    self:load('xc:black')
    self:size(width,height)
-
+   if colorspace == "RGBA" then
+      clib.MagickSetImageType(self.wand, clib.TrueColorMatteType)
+   end
    -- Export:
    clib.MagickSetImagePixels(self.wand,
                              0, 0, width, height,

--- a/test/opacity.lua
+++ b/test/opacity.lua
@@ -1,0 +1,11 @@
+local gm = require 'graphicsmagick'
+
+local rgb = gm.Image('lena.jpg'):toTensor("float", "RGB", "DHW")
+local rgba = torch.FloatTensor(4, rgb:size(2), rgb:size(3))
+rgba[1]:copy(rgb[1])
+rgba[2]:copy(rgb[2])
+rgba[3]:copy(rgb[3])
+rgba[4]:fill(0.5) -- alpha
+
+gm.Image(rgba, "RGBA", "DHW"):format("PNG"):save("opacity50.png")
+-- see saved image


### PR DESCRIPTION
`fromTensor(tensor, "RGBA", "DHW")` does not work correctly.
This PR fixes that issue.

Reproducible code:
```
local gm = require 'graphicsmagick'

local rgb = gm.Image('lena.jpg'):toTensor("float", "RGB", "DHW")
local rgba = torch.FloatTensor(4, rgb:size(2), rgb:size(3))
rgba[1]:copy(rgb[1])
rgba[2]:copy(rgb[2])
rgba[3]:copy(rgb[3])
rgba[4]:fill(0.5) -- alpha

gm.Image(rgba, "RGBA", "DHW"):format("PNG"):save("opacity50.png")
-- see saved image
```
Before fix: opacity50.png is 8-bit/color RGB. (alpha channel was removed)
After fix: opacity50.png is 8-bit/color RGBA.
