### PR TITLE
add missing error check for `MagickReadImageBlob`

### DIFF
--- a/test/corrupt.lua
+++ b/test/corrupt.lua
@@ -1,8 +1,25 @@
 local gm = require('graphicsmagick')
 
+local readfile = function(fn)
+  local f = io.open(fn,"rb")
+  if not f then return nil end
+  local data = f:read("*all")
+  f:close()
+  return data
+end
+
+local ok
+
 -- load a corrupted JPEG created with zzuf:
 --     zzuf -r 0.01 -s 1234 < city.jpg > city-corrupt.jpg
-local ok, err = pcall(gm.Image, 'city-corrupt.jpg')
+ok = pcall(gm.Image, 'city-corrupt.jpg')
 
 -- check opening failed without malloc error or core dumped
-assert(not ok)
+assert(not ok, 'corrupted JPEG should not be loaded')
+
+-- load this corrupted JPEG from a string
+local str = assert(readfile('city-corrupt.jpg'))
+local img = gm.Image()
+ok = pcall(img.fromString, img, str)
+
+assert(not ok, 'corrupted JPEG should not be loaded')

--- a/test/loadDirectory.lua
+++ b/test/loadDirectory.lua
@@ -1,11 +1,12 @@
 
--- 
+--
 -- this script demonstrates how to load a list of images from
 -- a directoty, by using GraphicsMagick's ability to load
 -- the smallest size required
 --
 
 gm = require 'graphicsmagick'
+require 'torch'
 require 'pl'
 
 opt = {
@@ -23,8 +24,13 @@ images = {}
 t = torch.Timer()
 for _,file in ipairs(files) do
    if file:lower():find('jpg$') or file:lower():find('jpeg$') then
-      local img = gm.Image(file):size(opt.maxsize):toTensor('byte', 'RGB', 'DHW')
-      table.insert(images, img)
+      local ok, img = pcall(gm.Image, file)
+      if ok then
+         img = img:size(opt.maxsize):toTensor('byte', 'RGB', 'DHW')
+         table.insert(images, img)
+      else
+         print('WARNING: skipping ' .. file .. '(' .. img .. ')')
+      end
    end
 end
 passed = t:time().real
@@ -39,8 +45,13 @@ images = {}
 t = torch.Timer()
 for _,file in ipairs(files) do
    if file:lower():find('jpg$') or file:lower():find('jpeg$') then
-      local img = gm.Image(file, opt.maxsize):size(opt.maxsize):toTensor('byte', 'RGB', 'DHW')
-      table.insert(images, img)
+      local ok, img = pcall(gm.Image, file, opt.maxsize)
+      if ok then
+         img = img:size(opt.maxsize):toTensor('byte', 'RGB', 'DHW')
+         table.insert(images, img)
+      else
+         print('WARNING: skipping ' .. file .. '(' .. img .. ')')
+      end
    end
 end
 passed = t:time().real


### PR DESCRIPTION
This applies for `fromString` and `fromBlob` calls.

The error reporting logic is now wrapped under a helper function.