### PR TITLE
Fix the definition of FilterTypes enum

### DIFF
--- a/Image.lua
+++ b/Image.lua
@@ -55,25 +55,9 @@ ffi.cdef
     CubicFilter,
     CatromFilter,
     MitchellFilter,
-    JincFilter,
-    SincFilter,
-    SincFastFilter,
-    KaiserFilter,
-    WelshFilter,
-    ParzenFilter,
-    BohmanFilter,
-    BartlettFilter,
-    LagrangeFilter,
     LanczosFilter,
-    LanczosSharpFilter,
-    Lanczos2Filter,
-    Lanczos2SharpFilter,
-    RobidouxFilter,
-    RobidouxSharpFilter,
-    CosineFilter,
-    SplineFilter,
-    LanczosRadiusFilter,
-    SentinelFilter
+    BesselFilter,
+    SincFilter
   } FilterTypes;
 
   typedef enum


### PR DESCRIPTION
It seems that `FilterTypes` was copied from ImageMagick.
This PR fixes `FilterTypes` with GraphcisMagick's FilterTypes.

[ImageMagick's FilterTypes](https://github.com/ImageMagick/ImageMagick/blob/22d1e094559e53ee6661c2b361343153a3c402d8/MagickCore/resample.h#L32)
[GraphicsMagick's FilterTypes]( http://hg.code.sf.net/p/graphicsmagick/code/file/dc00237464e4/magick/image.h#l276)

This commit will break some applications that is using this package but we should fix this issue, I think.
