### PR TITLE
Fixed: Memory leak

### DIFF
--- a/Image.lua
+++ b/Image.lua
@@ -213,7 +213,7 @@ ffi.cdef
   unsigned int MagickSetSize( MagickWand *wand, const unsigned long columns, const unsigned long rows );
 
   // Image format (JPEG, PNG, ...)
-  const char* MagickGetImageFormat(MagickWand* wand);
+  char* MagickGetImageFormat(MagickWand* wand);
   MagickBooleanType MagickSetImageFormat(MagickWand* wand, const char* format);
 
   // Raw data:
@@ -511,7 +511,7 @@ function Image:format(format)
       return self
    else
       -- Get format:
-      format = ffi.string(clib.MagickGetImageFormat(self.wand))
+      format = ffi.string(ffi.gc(clib.MagickGetImageFormat(self.wand), ffi.C.free))
    end
    return format
 end


### PR DESCRIPTION
`const char * MagickGetImageFormat( MagickWand *wand );`  should be `char * MagickGetImageFormat( MagickWand *wand );` , I think the [document](http://www.graphicsmagick.org/wand/magick_wand.html#magickgetimageformat) is not right.  
And, in `Image:format` method, it should be release memory for the `point value` returned by `MagickGetImageFormat`  method.