### PR TITLE
Fix to work on Lua52

### DIFF
--- a/Image.lua
+++ b/Image.lua
@@ -628,7 +628,7 @@ function Image:colorspace(colorspace)
       return self
    else
       -- Get format:
-      colorspace = tonumber(ffi.cast('double', clib.MagickGetImageColorspace(self.wand)))
+      colorspace = tonumber(clib.MagickGetImageColorspace(self.wand))
 
       colorspace = colorspaces[colorspace]
    end


### PR DESCRIPTION
This PR fixes a following error on Lua 5.2 (When torch is installed with `TORCH_LUA_VERSION=LUA52 ./install.sh`).
```
/home/nagadomi/torch/install/bin/lua: unable to convert argument 1 from cdata<double> to cdata<intptr_t>
stack traceback:
	[C]: in function 'tonumber'
	...omi/torch/install/share/lua/5.2/graphicsmagick/Image.lua:631: in function 'colorspace'
```
I tested it works on LuaJIT 2.1 and Lua 5.2.
